### PR TITLE
Handle broken addresses in ToHostName filter more gracefully

### DIFF
--- a/repoze/postoffice/filters.py
+++ b/repoze/postoffice/filters.py
@@ -25,7 +25,10 @@ class ToHostnameFilter(object):
         for addr in addrs:
             lt = addr.find('<')
             if lt != -1:
-                addr = addr[lt+1:addr.rindex('>')]
+                gt = addr.rfind('>')
+                if gt == -1:
+                    gt = None
+                addr = addr[lt+1:gt]
             if '@' not in addr:
                 continue
             hostname = addr.split('@')[1].lower()

--- a/repoze/postoffice/tests/test_filters.py
+++ b/repoze/postoffice/tests/test_filters.py
@@ -21,6 +21,9 @@ class TestToHostnameFilter(unittest.TestCase):
         msg['To'] = 'Chris <chris@example.com>'
         self.assertEqual(fut(msg),
                          'to_hostname: chris@example.com matches example.com')
+        msg['To'] = 'Chris <chris@example.com'
+        self.assertEqual(fut(msg),
+                         'to_hostname: chris@example.com matches example.com')
 
     def test_relative(self):
         fut = self._make_one('.example.com')


### PR DESCRIPTION
We had a problem manifesting in this traceback:

Traceback (most recent call last):
  File "bin/postoffice", line 111, in <module>
    repoze.postoffice.script.main()
  File "/srv/multikarl/production/15/eggs/repoze.postoffice-0.21-py2.6.egg/repoze/postoffice/script.py", line 75, in main
    return ConsoleScript()()
  File "/srv/multikarl/production/15/eggs/repoze.postoffice-0.21-py2.6.egg/repoze/postoffice/script.py", line 48, in **call**
    po.import_messages(self.log)
  File "/srv/multikarl/production/15/eggs/repoze.postoffice-0.21-py2.6.egg/repoze/postoffice/api.py", line 177, in import_messages
    self._import_message(message, log)
  File "/srv/multikarl/production/15/eggs/repoze.postoffice-0.21-py2.6.egg/repoze/postoffice/api.py", line 220, in _import_message
    if not filters or not _filters_match(filters, message):
  File "/srv/multikarl/production/15/eggs/repoze.postoffice-0.21-py2.6.egg/repoze/postoffice/api.py", line 396, in _filters_match
    if not filter_(message):
  File "/srv/multikarl/production/15/eggs/repoze.postoffice-0.21-py2.6.egg/repoze/postoffice/filters.py", line 28, in **call**
    addr = addr[lt+1:addr.rindex('>')]
ValueError: substring not found

This stopped any incoming mail processing.

The attached patch fixes it by accepting anything after the "<" as the potential email address and avoids getting stuck.
